### PR TITLE
feat: Add the initial Anthropic SDK implementation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,8 @@ trim_trailing_whitespace = true
 [*.{go,mod}]
 indent_size = 4
 tab_width = 4
+
+[*.md]
+indent_size = 4
+tab_width = 4
+trim_trailing_whitespace = false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,37 @@
+name: PR
+
+on:
+  pull_request:
+    branches:
+    - main
+    paths-ignore:
+    - .editorconfig
+    - .gitignore
+    - LICENSE.md
+    - README.md
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+    - name: Check formatting
+      run: test -z "$(go fmt ./...)"
+
+  build:
+    name: Build
+    needs: [ verify ]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 *.out
 *.so
 *.test
+/examples
 go.work

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Anthropic SDK for Go
 
+Client library for interacting with the [Anthropic] safety-first language model
+REST APIs.
+
 ## Getting started
 
 ### Requirements
@@ -8,17 +11,54 @@
 
 ### Installation and usage
 
-TODO
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "os"
+
+    "github.com/unfunco/anthropic-sdk-go"
+)
+
+func main() {
+    ctx := context.Background()
+
+    transport := &anthropic.Transport{APIKey: os.Getenv("ANTHROPIC_API_KEY")}
+    claude := anthropic.NewClient(transport.Client())
+
+    if resp, httpResp, err := claude.Messages.Create(ctx, &anthropic.CreateMessageInput{
+        MaxTokens: 100,
+        Messages: []anthropic.Message{
+            {Content: "Hello, Claude!", Role: "user"},
+        },
+        Model: anthropic.Claude3Opus20240229,
+    }); err == nil {
+        fmt.Println(httpResp.StatusCode)
+        fmt.Println(resp)
+    } else {
+        _, _ = fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+}
+```
 
 ### Development and testing
 
-TODO
+Clone the repository and change into the `anthropic-sdk-go` directory.
+
+```bash
+git clone git@github.com:unfunco/anthropic-sdk-go.git
+cd anthropic-sdk-go
+```
 
 ## License
 
 © 2024 [Daniel Morris]\
 Made available under the terms of the [MIT License].
 
+[anthropic]: https://www.anthropic.com
 [daniel morris]: https://unfun.co
 [go]: https://go.dev
 [mit license]: LICENSE.md

--- a/anthropic.go
+++ b/anthropic.go
@@ -1,0 +1,109 @@
+// Package anthropic provides a client library for interacting with the
+// Anthropic safety-first language model REST APIs.
+package anthropic
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+const (
+	defaultAPIVersion = "2023-06-01"
+	defaultBaseURL    = "https://api.anthropic.com/v1/"
+	defaultUserAgent  = "unfunco/anthropic-sdk-go@v0.0.0"
+)
+
+// Client manages communication with the Anthropic REST API.
+type Client struct {
+	baseURL  *url.URL
+	client   *http.Client
+	reusable service
+
+	Messages *MessagesService
+}
+
+type service struct{ client *Client }
+
+// NewClient returns a new Anthropic REST API client.
+func NewClient(client *http.Client) *Client {
+	if client == nil {
+		client = &http.Client{}
+	}
+
+	claude := &Client{client: client}
+	claude.baseURL, _ = url.Parse(defaultBaseURL)
+	claude.reusable.client = claude
+	claude.Messages = (*MessagesService)(&claude.reusable)
+
+	return claude
+}
+
+// NewRequest creates an API request.
+func (c *Client) NewRequest(method, path string, body any) (*http.Request, error) {
+	u, err := c.baseURL.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf io.ReadWriter
+	if body != nil {
+		buf = &bytes.Buffer{}
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		err = enc.Encode(body)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := http.NewRequest(method, u.String(), buf)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("anthropic-version", defaultAPIVersion)
+	req.Header.Set("user-agent", defaultUserAgent)
+
+	if body != nil {
+		req.Header.Set("content-type", "application/json")
+	}
+
+	return req, nil
+}
+
+// Do sends an API request and returns the API response.
+func (c *Client) Do(ctx context.Context, req *http.Request, v any) (*http.Response, error) {
+	req = req.WithContext(ctx)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		return nil, err
+	}
+	//goland:noinspection GoUnhandledErrorResult
+	defer resp.Body.Close()
+
+	switch v := v.(type) {
+	case nil:
+	case io.Writer:
+		_, err = io.Copy(v, resp.Body)
+	default:
+		decErr := json.NewDecoder(resp.Body).Decode(v)
+		if decErr == io.EOF {
+			decErr = nil
+		}
+		if decErr != nil {
+			err = decErr
+		}
+	}
+
+	return resp, nil
+}

--- a/anthropic_test.go
+++ b/anthropic_test.go
@@ -1,0 +1,16 @@
+package anthropic
+
+import "testing"
+
+func TestNewClient(t *testing.T) {
+	c1 := NewClient(nil)
+	c2 := NewClient(nil)
+
+	if c1.client == c2.client {
+		t.Error("NewClient returned equal http.Clients but they should differ")
+	}
+}
+
+func TestClient_NewRequest(t *testing.T) {
+	_ = NewClient(nil)
+}

--- a/messages.go
+++ b/messages.go
@@ -1,0 +1,95 @@
+package anthropic
+
+import (
+	"context"
+	"net/http"
+)
+
+type MessagesService service
+
+// Message defines ...
+type Message struct {
+	Content string `json:"content"`
+	Role    string `json:"role"`
+}
+
+// Usage defines billing and rate-limit usage information.
+// Billing and rate-limiting are driven by token counts, since tokens represent
+// the underlying cost to Anthropic.
+type Usage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+type Content struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// CreateMessageInput defines a structured list of input messages.
+type CreateMessageInput struct {
+	// MaxTokens defines the maximum number of tokens to generate before
+	// stopping. Token generation may stop before reaching this limit, this only
+	// specifies the absolute maximum number of tokens to generate. Different
+	// models have different maximum token limits.
+	MaxTokens int `json:"max_tokens"`
+	// Messages are the input messages, models are trained to operate on
+	// alternating user and assistant conversational turns. When creating a new
+	// message, prior conversational turns can be specified with this field.
+	Messages []Message `json:"messages"`
+	// Model defines the language model that will be used to complete the
+	// prompt. See model.go for a list of available models.
+	Model LanguageModel `json:"model"`
+	// StopSequences defines custom text sequences that will cause the model to
+	// stop generating.
+	StopSequences []string `json:"stop_sequences,omitempty"`
+	// System provides a means of specifying context and instructions to the
+	// model, such as specifying a particular goal or role.
+	System string `json:"system,omitempty"`
+	// Temperature defines the amount of randomness injected into the response.
+	// Note that even with a temperature of 0.0, results will not be fully
+	// deterministic.
+	Temperature *float64 `json:"temperature,omitempty"`
+	// TopK is used to remove long tail low probability responses.
+	// Recommended for advanced use cases only. You usually only need to use
+	// Temperature.
+	TopK *int `json:"top_k,omitempty"`
+	// TopP (nucleus-sampling) defines the cumulative probability of the highest probability.
+	// Recommended for advanced use cases only. You usually only need to use
+	// Temperature.
+	TopP *float64 `json:"top_p,omitempty"`
+}
+
+type CreateMessageOutput struct {
+	Id           *string    `json:"id"`
+	Type         *string    `json:"type"`
+	Role         *string    `json:"role"`
+	Model        *string    `json:"model"`
+	StopSequence *string    `json:"stop_sequence"`
+	StopReason   *string    `json:"stop_reason"`
+	Content      []*Content `json:"content"`
+	Usage        *Usage     `json:"usage"`
+}
+
+func (c *CreateMessageOutput) String() string {
+	return c.Content[0].Text
+}
+
+// Create creates a new message using the provided options.
+func (c *MessagesService) Create(
+	ctx context.Context,
+	in *CreateMessageInput,
+) (*CreateMessageOutput, *http.Response, error) {
+	req, err := c.client.NewRequest(http.MethodPost, "messages", in)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	out := new(CreateMessageOutput)
+	resp, err := c.client.Do(ctx, req, out)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return out, resp, nil
+}

--- a/messages_test.go
+++ b/messages_test.go
@@ -1,0 +1,1 @@
+package anthropic

--- a/model.go
+++ b/model.go
@@ -1,0 +1,15 @@
+package anthropic
+
+// LanguageModel represents a language model that can be used to complete
+// a prompt.
+// https://docs.anthropic.com/claude/docs/models-overview
+type LanguageModel string
+
+const (
+	Claude3Opus20240229   LanguageModel = "claude-3-opus-20240229"
+	Claude3Sonnet20240229 LanguageModel = "claude-3-sonnet-20240229"
+	Claude3Haiku20240229  LanguageModel = "claude-3-haiku-20240307"
+	Claude21              LanguageModel = "claude-2.1"
+	Claude20              LanguageModel = "claude-2.0"
+	ClaudeInstant12       LanguageModel = "claude-instant-1.2"
+)

--- a/transport.go
+++ b/transport.go
@@ -1,0 +1,39 @@
+package anthropic
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+)
+
+// Transport ...
+type Transport struct {
+	APIKey string
+}
+
+func (t *Transport) Client() *http.Client {
+	return &http.Client{
+		Transport: t,
+	}
+}
+
+// RoundTrip implements the http.RoundTripper interface.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.APIKey == "" {
+		return nil, errors.New("API key is required")
+	}
+
+	newReq := new(http.Request)
+	*newReq = *req
+	newReq.URL = new(url.URL)
+	*newReq.URL = *req.URL
+
+	newReq.Header = make(http.Header, len(req.Header))
+	for k, v := range req.Header {
+		newReq.Header[k] = v
+	}
+
+	newReq.Header.Set("x-api-key", t.APIKey)
+
+	return http.DefaultTransport.RoundTrip(newReq)
+}

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,0 +1,1 @@
+package anthropic


### PR DESCRIPTION
Add the initial implementation which covers the Messages functionality of the Anthropic API, this does not yet support streaming with SSE nor does it support anything other than text as an input, it has only been tested with the most basic of prompts.