### PR TITLE
chore: Push version changes to the release branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,4 +56,4 @@ jobs:
         git config user.email "48985810+david-letterman@users.noreply.github.com"
         git add anthropic.go
         git commit -m "Configure version number"
-        git push
+        git push origin release-please--branches--main


### PR DESCRIPTION
Previously, since no remote and branch was specified, it was attempting to push to the main branch, and failing since the main branch is protected. This updates the CI workflow so that the version number update is pushed to the release branch.