### PR TITLE
fix: Fix an ineffectual assignment to err

### DIFF
--- a/anthropic.go
+++ b/anthropic.go
@@ -127,5 +127,5 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v any) (*http.Respon
 		}
 	}
 
-	return resp, nil
+	return resp, err
 }


### PR DESCRIPTION
Caught by the lint tooling added to GitHub Actions.