### PR TITLE
chore: Fix a broken automated commit process

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,6 @@ jobs:
         sed -i '/const semanticVersion = \"v[0-9]*\.[0-9]*\.[0-9]*\"/cconst semanticVersion = \"v$version\"' version.go
         git config --local user.name "David Letterman"
         git config --local user.email "48985810+david-letterman@users.noreply.github.com"
-        git add anthropic.go
+        git add version.go
         git commit -m "chore: Configure the version number"
         git push


### PR DESCRIPTION
This is attempting to add the wrong file when it updates the version number as part of the release workflow.