### PR TITLE
feat: Add convenience methods for pointer creation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,9 +53,9 @@ jobs:
         manifest-file: .github/release-manifest.json
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Update the version number
-      if: ${{ steps.release.outputs.prs_created == 'true' }}
+      if: steps.release.outputs.prs_created && steps.release.outputs.pr != null
       run: |
-        git config pull.ff only
+        git config pull.rebase true
         git checkout ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
         git pull origin ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
         version=$(jq -r '."."' .github/release-manifest.json)
@@ -65,4 +65,4 @@ jobs:
         git config --local user.email "48985810+david-letterman@users.noreply.github.com"
         git add version.go
         git commit -m "chore: Configure the version number"
-        git push
+        git push origin ${{ fromJSON(steps.release.outputs.pr).headBranchName }}

--- a/anthropic.go
+++ b/anthropic.go
@@ -130,3 +130,9 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v any) (*http.Respon
 
 	return resp, err
 }
+
+// Float64 returns a pointer to a float64 value.
+func Float64(v float64) *float64 { return &v }
+
+// Int returns a pointer to an int value.
+func Int(v int) *int { return &v }


### PR DESCRIPTION
Add two convenience methods for creating pointers, to `int` and `float64` values, so that the Temperature, TopK, and TopP options can be specified more easily.