### PR TITLE
chore: Update release-please-action organisation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
         fetch-depth: 0
     - name: Prepare a release
       id: release
-      uses: google-github-actions/release-please-action@v4
+      uses: googleapis/release-please-action@v4
       with:
         config-file: .github/release-config.json
         manifest-file: .github/release-manifest.json


### PR DESCRIPTION
Google have moved the release-please-action from the google-github-actions organisation to the googleapis organisation.

This GitHub issue comment states that future development will be done in the googleapis organisation.

https://github.com/googleapis/release-please-action/issues/980#issuecomment-2108208115